### PR TITLE
Phase 6 v6.1

### DIFF
--- a/phase_6_CIS-17C_project2/Sorting.cpp
+++ b/phase_6_CIS-17C_project2/Sorting.cpp
@@ -1,0 +1,89 @@
+#include "Sorting.h"
+
+// Recursive merge sort, split the task down the middle.
+void mrgSort(Data *a, int beg, int end)
+{
+    int center = (beg + end) / 2;
+    //Base Condition: a half of one or zero elements is already sorted
+    //Recursion: each gated call recurses on its half independently
+    if ((center - beg) > 1)
+    {
+        mrgSort(a, beg, center);
+    }
+    if ((end - center) > 1)
+    {
+        mrgSort(a, center, end);
+    }
+    merge(a, beg, center, end);
+}
+
+// Merge two sorted halves through the working buffer, then copy back.
+void merge(Data *a, int beg, int nlow, int nhigh)
+{
+    int span = nhigh - beg;
+    int cntl = beg;
+    int cnth = nlow;
+    for (int i = 0; i < span; i++)
+    {
+        if (cntl == nlow)
+        {
+            a->working[i] = a->sortit[cnth++];
+        }
+        else if (cnth == nhigh)
+        {
+            a->working[i] = a->sortit[cntl++];
+        }
+        else if (a->sortit[cntl] < a->sortit[cnth])
+        {
+            a->working[i] = a->sortit[cntl++];
+        }
+        else
+        {
+            a->working[i] = a->sortit[cnth++];
+        }
+    }
+    for (int i = 0; i < span; i++)
+    {
+        a->sortit[beg + i] = a->working[i];
+    }
+}
+
+// Quick sort, Hoare partition, recursive on each side.
+void qkSort(int *a, int lo, int hi)
+{
+    //Base Condition: lo >= hi means the range has one or zero elements
+    if (lo < hi)
+    {
+        int p = partition(a, lo, hi);
+        //Recursion
+        qkSort(a, lo, p);
+        qkSort(a, p + 1, hi);
+    }
+}
+
+// Hoare partition. Pivot is the middle element; converging i / j
+// indices swap out-of-place values until they cross.
+int partition(int *a, int lo, int hi)
+{
+    int pivot = a[(lo + hi) / 2];
+    int i = lo - 1;
+    int j = hi + 1;
+    while (true)
+    {
+        do
+        {
+            i++;
+        } while (a[i] < pivot);
+        do
+        {
+            j--;
+        } while (a[j] > pivot);
+        if (i >= j)
+        {
+            return j;
+        }
+        int t = a[i];
+        a[i] = a[j];
+        a[j] = t;
+    }
+}

--- a/phase_6_CIS-17C_project2/Sorting.h
+++ b/phase_6_CIS-17C_project2/Sorting.h
@@ -1,0 +1,28 @@
+#ifndef SORTING_H
+#define SORTING_H
+#include <cstddef>
+using namespace std;
+
+// Working-pair data for merge sort. sortit holds the array being sorted,
+// working is a pre-allocated buffer the merge step writes into and copies
+// back from, which avoids per-recursion-frame allocations.
+struct Data
+{
+    int size;
+    int *sortit;
+    int *working;
+};
+
+// Merge sort: recursive split, then merge through the working buffer.
+void mrgSort(Data *, int beg, int end);
+
+// Merge two sorted halves [beg, nlow) and [nlow, nhigh).
+void merge(Data *, int beg, int nlow, int nhigh);
+
+// Quick sort with Hoare partition.
+void qkSort(int *, int lo, int hi);
+
+// Hoare partition. Returns the partition index for qkSort recursion.
+int partition(int *, int lo, int hi);
+
+#endif

--- a/phase_6_CIS-17C_project2/sorting_study.cpp
+++ b/phase_6_CIS-17C_project2/sorting_study.cpp
@@ -7,6 +7,7 @@ Purpose: Timing study driver for mrgSort and qkSort from Sorting.h.
 */
 
 #include <iostream>
+#include <iomanip>
 #include <fstream>
 #include <cstdlib>
 #include <ctime>
@@ -35,7 +36,10 @@ int main(int argc, char **argv)
     int tQk[NSIZE];
     int tMr[NSIZE];
 
-    cout << "N\tQSort\tMerge  (milliseconds)" << endl;
+    cout << setw(10) << "N"
+         << setw(10) << "QSort"
+         << setw(10) << "Merge"
+         << "  (milliseconds)" << endl;
 
     for (int s = 0; s < NSIZE; s++)
     {
@@ -53,7 +57,9 @@ int main(int argc, char **argv)
         tMr[s] = (int)duration_cast<milliseconds>(steady_clock::now() - t0).count();
         destroy(a);
 
-        cout << n << "\t" << tQk[s] << "\t" << tMr[s] << endl;
+        cout << setw(10) << n
+             << setw(10) << tQk[s]
+             << setw(10) << tMr[s] << endl;
     }
 
     writeFit("quick_time.txt", NSIZE, SIZES, tQk);

--- a/phase_6_CIS-17C_project2/sorting_study.cpp
+++ b/phase_6_CIS-17C_project2/sorting_study.cpp
@@ -1,0 +1,112 @@
+/*
+Name: Samuel Gerungan
+Date: 6/2/26
+Purpose: Timing study driver for mrgSort and qkSort from Sorting.h.
+         Times each over a range of N and writes plot files.
+         Build: g++ -std=c++17 -DSORT_STUDY Sorting.cpp sorting_study.cpp -o sort_study
+*/
+
+#include <iostream>
+#include <fstream>
+#include <cstdlib>
+#include <ctime>
+#include <chrono>
+#include "Sorting.h"
+using namespace std;
+using namespace std::chrono;
+
+// Seven N values spanning 10K to 1M. Range is large enough to expose the
+// O(n log n) growth of both sorts without making the driver runtime long
+// enough to slow down development. Actual game-scale sorts run on N <= 20
+// (a hand) and N <= 200 (the leaderboard), so this study sits well above
+// what the game itself needs.
+const int NSIZE = 7;
+const int SIZES[NSIZE] = {10000, 50000, 100000, 250000, 500000, 750000, 1000000};
+
+Data *fill(int);
+void destroy(Data *);
+int mkRndS();
+void writeFit(const char *, int, const int *, const int *);
+
+int main(int argc, char **argv)
+{
+    srand(static_cast<unsigned int>(time(0)));
+
+    int tQk[NSIZE];
+    int tMr[NSIZE];
+
+    cout << "N\tQSort\tMerge  (milliseconds)" << endl;
+
+    for (int s = 0; s < NSIZE; s++)
+    {
+        int n = SIZES[s];
+
+        Data *a = fill(n);
+        steady_clock::time_point t0 = steady_clock::now();
+        qkSort(a->sortit, 0, n - 1);
+        tQk[s] = (int)duration_cast<milliseconds>(steady_clock::now() - t0).count();
+        destroy(a);
+
+        a = fill(n);
+        t0 = steady_clock::now();
+        mrgSort(a, 0, a->size);
+        tMr[s] = (int)duration_cast<milliseconds>(steady_clock::now() - t0).count();
+        destroy(a);
+
+        cout << n << "\t" << tQk[s] << "\t" << tMr[s] << endl;
+    }
+
+    writeFit("quick_time.txt", NSIZE, SIZES, tQk);
+    writeFit("merge_time.txt", NSIZE, SIZES, tMr);
+
+    return 0;
+}
+
+// Allocate a Data block with n random ints in sortit and an n-sized working
+// buffer for merge to stage rebuilt halves into.
+Data *fill(int n)
+{
+    Data *data = new Data;
+    data->size = n;
+    data->sortit = new int[n];
+    data->working = new int[n];
+    for (int i = 0; i < n; i++)
+    {
+        data->sortit[i] = mkRndS();
+    }
+    return data;
+}
+
+void destroy(Data *a)
+{
+    delete[] a->sortit;
+    delete[] a->working;
+    delete a;
+}
+
+// 4-byte random int built by shifting one 16-bit rand into the high half and
+// adding a second 16-bit rand for the low half. rand() alone caps at 15 bits.
+int mkRndS()
+{
+    int temp = rand();
+    temp <<= 16;
+    return temp + rand();
+}
+
+// Write a curve_fit input: count on line 1, X row on line 2, Y row on line 3.
+// Format mirrors the Lehr Recursions and Sorts lab plot file exactly.
+void writeFit(const char *name, int n, const int *x, const int *y)
+{
+    ofstream fout(name);
+    fout << n << "\n";
+    for (int i = 0; i < n; i++)
+    {
+        fout << x[i] << " ";
+    }
+    fout << "\n";
+    for (int i = 0; i < n; i++)
+    {
+        fout << y[i] << " ";
+    }
+    fout << "\n";
+}

--- a/phase_6_CIS-17C_project2/unoV6.0.cpp
+++ b/phase_6_CIS-17C_project2/unoV6.0.cpp
@@ -10,6 +10,7 @@ Purpose: UNO! Game Version 6.0
 #include <cstdlib>
 #include <string>
 #include <list>
+#include <vector>
 #include <iterator>
 #include <stack>
 #include <queue>
@@ -18,6 +19,7 @@ Purpose: UNO! Game Version 6.0
 #include <algorithm>
 #include <random>
 #include <fstream>
+#include <sstream>
 #include "Player.h"
 #include "HumanPlayer.h"
 #include "NPCPlayer.h"
@@ -56,6 +58,11 @@ void plyrTrn(Player &, Player &, stack<Card> &, queue<Card> &, bool &);         
 void npcTrn(Player &, Player &, stack<Card> &, queue<Card> &, bool &);                                 // Function to process npc logic
 CardClr pickClr(const list<Card> &);                                                                   // tally NPC hand by color via unordered_map and pick the dominant one
 unordered_set<Card> legalPlays(const list<Card> &, const Card &);                                      // hashed cache of playable cards on the active card
+void mrgSort(vector<Card> &, int beg, int end);                                                        // Recursive merge sort over the hand vector; mirrors the lab Data* shape
+void merge(vector<Card> &, int beg, int nlow, int nhigh);                                              // Merge step for mrgSort; allocates one span-sized local working buffer
+void showSrt(Player &, const unordered_set<Card> &);                                                   // Display the hand sorted via mrgSort with playable markers
+void qkSort(vector<pair<string, Scores>> &, int lo, int hi);                                           // Recursive quick sort over the leaderboard vector; sorts by trns ascending
+int partition(vector<pair<string, Scores>> &, int lo, int hi);                                         // Hoare partition keyed on Scores.trns; returns the partition index
 void calcScrs(Player &, Player &npc);
 void readScrs();
 void updtScr(const string &, const Scores &);
@@ -405,6 +412,125 @@ bool operator==(const Card &a, const Card &b)
     return a.color == b.color && a.suit == b.suit;
 }
 
+// Recursive merge sort, vector<Card> overload mirroring the Data* shape.
+void mrgSort(vector<Card> &a, int beg, int end)
+{
+    int center = (beg + end) / 2;
+    //Base Condition: a half of one or zero elements is already sorted
+    //Recursion: each gated call recurses on its half independently
+    if ((center - beg) > 1)
+    {
+        mrgSort(a, beg, center);
+    }
+    if ((end - center) > 1)
+    {
+        mrgSort(a, center, end);
+    }
+    merge(a, beg, center, end);
+}
+
+// Merge sorted halves through a span-sized work vector allocated per call.
+void merge(vector<Card> &a, int beg, int nlow, int nhigh)
+{
+    int span = nhigh - beg;
+    vector<Card> work(span);
+    int cntl = beg;
+    int cnth = nlow;
+    for (int i = 0; i < span; i++)
+    {
+        if (cntl == nlow)
+        {
+            work[i] = a[cnth++];
+        }
+        else if (cnth == nhigh)
+        {
+            work[i] = a[cntl++];
+        }
+        else if (a[cntl] < a[cnth])
+        {
+            work[i] = a[cntl++];
+        }
+        else
+        {
+            work[i] = a[cnth++];
+        }
+    }
+    for (int i = 0; i < span; i++)
+    {
+        a[beg + i] = work[i];
+    }
+}
+
+// [s] menu path; mrgSort over a vector copy so the list<Card> indexing stays.
+void showSrt(Player &p1, const unordered_set<Card> &legal)
+{
+    vector<Card> buf(p1.hand.begin(), p1.hand.end());
+    mrgSort(buf, 0, (int)buf.size());
+
+    string colors[] = {"Red", "Blue", "Yellow", "Green", "Wild"};
+    string values[] = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "SKIP", "DRAW 2", "DRAW 4"};
+
+    cout << "--------------------------------------------------------" << endl;
+    cout << "Hand (mergeSort view):" << endl;
+    for (int i = 0; i < (int)buf.size(); i++)
+    {
+        cout << "  ";
+        if (buf[i].color == WILD)
+        {
+            cout << "Wild";
+        }
+        else
+        {
+            cout << values[buf[i].suit] << " " << colors[buf[i].color];
+        }
+        if (legal.find(buf[i]) != legal.end())
+        {
+            cout << "  (playable)";
+        }
+        cout << endl;
+    }
+    cout << "--------------------------------------------------------" << endl;
+}
+
+// Recursive quick sort, vector<pair<string,Scores>> overload keyed on trns ascending.
+void qkSort(vector<pair<string, Scores>> &a, int lo, int hi)
+{
+    //Base Condition: lo >= hi means the range has one or zero elements
+    if (lo < hi)
+    {
+        int p = partition(a, lo, hi);
+        //Recursion
+        qkSort(a, lo, p);
+        qkSort(a, p + 1, hi);
+    }
+}
+
+// Hoare partition over the leaderboard vector. Pivot is the middle entry's trns.
+int partition(vector<pair<string, Scores>> &a, int lo, int hi)
+{
+    int pivot = a[(lo + hi) / 2].second.trns;
+    int i = lo - 1;
+    int j = hi + 1;
+    while (true)
+    {
+        do
+        {
+            i++;
+        } while (a[i].second.trns < pivot);
+        do
+        {
+            j--;
+        } while (a[j].second.trns > pivot);
+        if (i >= j)
+        {
+            return j;
+        }
+        pair<string, Scores> t = a[i];
+        a[i] = a[j];
+        a[j] = t;
+    }
+}
+
 // Build the playable-cards cache for one player turn.
 unordered_set<Card> legalPlays(const list<Card> &hand, const Card &active)
 {
@@ -469,7 +595,8 @@ void usrInt(Player &p1, Player &npc, Card &actvCrd, const unordered_set<Card> &l
     // Prompt for how player wants to proceed
     cout << "--------------------------------------------------------" << endl;
     cout << setw(16) << " " << "What would you like to do?" << endl;
-    cout << "| Choose a card to play [0-" << p1.hand.size() << "] | Type -1 to draw a card | " << endl;
+    cout << "| Choose a card to play [0-" << p1.hand.size() << "] | Type -1 to draw a card |" << endl;
+    cout << "| [s] show sorted (mergeSort) |" << endl;
 }
 
 // Card Info to Decipher card information
@@ -622,8 +749,6 @@ void play(Player &p1, Player &npc, int choice, stack<Card> &discard, queue<Card>
 // Player turn funciton sequence
 void plyrTrn(Player &p1, Player &npc, stack<Card> &discard, queue<Card> &deck, bool &turn)
 {
-    int choice;
-
     while (turn == true)
     {
         turn = false;                                                   // Default set turn to false at the start of the loop
@@ -631,15 +756,23 @@ void plyrTrn(Player &p1, Player &npc, stack<Card> &discard, queue<Card> &deck, b
         usrInt(p1, npc, discard.top(), legal);                          // Display the current game state; top of pile is the active card
         cout << "--------------------------------------------------------" << endl;
         cout << "Which card would you like to play?: "; // Prompt for visual Clarity
-        cin >> choice;                                  // Input player choice
+
+        string raw;
+        cin >> raw; // Read as text so [s] is distinguishable from an index
+
         cout << "========================================================" << endl;
 
-        // disPrvSts(*p1); //Future implementation to add option to display private stats of player
-
-        if (cin.fail())
+        if (raw == "s" || raw == "S")
         {
-            cin.clear();
-            cin.ignore(1000, '\n');
+            showSrt(p1, legal); // mergeSort path; redisplay then loop back
+            turn = true;
+            continue;
+        }
+
+        int choice;
+        stringstream ss(raw);
+        if (!(ss >> choice) || !ss.eof())
+        {
             cout << "Invalid input. Try again." << endl;
             turn = true;
         }
@@ -895,15 +1028,27 @@ void readScrs()
         return;
     }
 
-    cout << "\n"
-         << setw(12) << " " << "=== SCORE HISTORY ===\n";
+    // Dump the hash table into a vector and sort by trns ascending. Manual loop
+    // because HashTable::iterator does not expose iterator_traits typedefs.
+    vector<pair<string, Scores>> board;
+    for (HashTable<Scores>::iterator it = scores.begin(); it != scores.end(); ++it)
+    {
+        board.push_back(*it);
+    }
+    if (!board.empty())
+    {
+        qkSort(board, 0, (int)board.size() - 1);
+    }
 
-    // for_each over the hash table's forward iterator; bucket order, not name order.
+    cout << "\n"
+         << setw(10) << " " << "=== LEADERBOARD (quickSort, turns asc) ===\n";
+
+    // for_each over the sorted vector keeps the Phase 5 rubric line in place.
     int count = 1;
-    for_each(scores.begin(), scores.end(),
+    for_each(board.begin(), board.end(),
              [&count](const pair<string, Scores> &rec)
              {
-                 cout << setw(15) << " " << "Record " << count++ << ":\n";
+                 cout << setw(15) << " " << "Rank " << count++ << ":\n";
                  cout << setw(15) << " " << "  Player  : " << rec.first << '\n';
                  cout << setw(15) << " " << "  Turns   : " << rec.second.trns << '\n';
                  cout << setw(15) << " " << "  HiCombo : " << rec.second.cmbHi << "\n\n";


### PR DESCRIPTION
## Summary

Phase 6 sub-version v6.1 (recursive sorting cluster). Three steps land:

- **Step 05** (`sorting_h`): new `Sorting.h` / `Sorting.cpp` / `sorting_study.cpp`. Paired recursive merge sort and recursive quick sort with Lehr-style `//Base Condition` + `//Recursion` markers; stand-alone timing-study driver compiles separately via `-DSORT_STUDY` and writes `quick_time.txt` / `merge_time.txt` plot input.
- **Step 06** (`sort_hand`): `mrgSort(vector<Card>&, int, int)` and `merge(vector<Card>&, int, int, int)` overloads added to `unoV6.0.cpp`; new `showSrt(Player&, const unordered_set<Card>&)` driven by a new menu option `[s] show sorted (mergeSort)` in `plyrTrn`. The Phase 5 `srtHnd` (`list::sort` on `(color, suit)`) stays put on every prompt display.
- **Step 07** (`sort_lb`): `qkSort(vector<pair<string,Scores>>&, int, int)` and `partition(vector<pair<string,Scores>>&, int, int)` overloads added; `readScrs` rewired to dump the `HashTable<Scores>` into a vector via a manual for-loop, sort by `trns` ascending, then walk the sorted vector with the preserved Phase 5 `for_each` rubric line. Header swap `SCORE HISTORY` -> `LEADERBOARD (quickSort, turns asc)`, row label `Record N` -> `Rank N`.

Both Phase 5 algorithm rubric lines (`list::sort` on the hand, `for_each` on the leaderboard) execute on the same data each consumer pass, alongside the new Phase 6 recursive-sort rubric lines.

Single-pass commit convention: the five atomic working commits (`fe8a55f` + `38434f5` + `c194e9f` + `1316a23` + `1196cd2`) folded into one `41c79d1 Phase 6 v6.1`. Backup tag `v6.1-backup-pre-rewrite` preserves the prior shape.

## Test plan

- [x] `g++ -std=c++17 -Wall unoV6.0.cpp NPCPlayer.cpp HumanPlayer.cpp -o uno` builds clean (zero warnings).
- [x] `g++ -std=c++17 -DSORT_STUDY Sorting.cpp sorting_study.cpp -o sort_study` builds clean.
- [x] Timing-study driver runs end-to-end, emits banner table over the 10K to 1M N range and writes the two plot-input files.
- [x] Focused verification driver `/tmp/leaderboard_check` seeds five records and prints them in `trns`-ascending order (Diana 9 / Alice 18 / Bob 27 / Eve 35 / Charlie 42), proving the Step 07 wire-in.
- [x] In-game `[s]` menu option fires `showSrt` and prints the hand with `(playable)` markers consistent with the standard view.