### PR TITLE
Phase 6 v6.2

### DIFF
--- a/phase_6_CIS-17C_project2/ScoreBST.cpp
+++ b/phase_6_CIS-17C_project2/ScoreBST.cpp
@@ -1,0 +1,145 @@
+#include "ScoreBST.h"
+#include <iostream>
+#include <iomanip>
+using namespace std;
+
+ScoreBST::ScoreBST()
+{
+    root = nullptr;
+}
+
+ScoreBST::~ScoreBST()
+{
+    destroy(root);
+}
+
+// Public insert delegates to the recursive helper threading the root pointer.
+void ScoreBST::insert(const string &name, const Scores &scr)
+{
+    insert(root, name, scr);
+}
+
+// Recursive insert; ordering is trns ascending, cmbHi descending on tie.
+void ScoreBST::insert(ScoreNode *&node, const string &name, const Scores &scr)
+{
+    //Base Condition: an empty slot becomes the new leaf
+    if (node == nullptr)
+    {
+        node = new ScoreNode{name, scr, nullptr, nullptr};
+        return;
+    }
+    //Recursion: walk left when the new record outranks the current node
+    bool less = (scr.trns < node->scr.trns)
+                || (scr.trns == node->scr.trns && scr.cmbHi > node->scr.cmbHi);
+    if (less)
+    {
+        insert(node->left, name, scr);
+    }
+    else
+    {
+        insert(node->right, name, scr);
+    }
+}
+
+// Post-order destroy frees children before the parent.
+void ScoreBST::destroy(ScoreNode *node)
+{
+    //Base Condition: a null subtree owns nothing
+    if (node == nullptr)
+    {
+        return;
+    }
+    //Recursion: free both children, then this node
+    destroy(node->left);
+    destroy(node->right);
+    delete node;
+}
+
+// Public in-order walk; rank counter starts at 1 and the helper advances it.
+void ScoreBST::inOrder() const
+{
+    cout << "\n"
+         << setw(10) << " " << "=== LEADERBOARD (BST in-order, turns asc) ===\n";
+    int rank = 1;
+    inOrder(root, rank);
+}
+
+// In-order walk prints left, current, right; rank advances on each visit.
+void ScoreBST::inOrder(ScoreNode *node, int &rank) const
+{
+    //Base Condition: an empty subtree contributes nothing
+    if (node == nullptr)
+    {
+        return;
+    }
+    //Recursion: left subtree, then this node, then right subtree
+    inOrder(node->left, rank);
+    cout << setw(15) << " " << "Rank " << rank++ << ":\n";
+    cout << setw(15) << " " << "  Player  : " << node->name << '\n';
+    cout << setw(15) << " " << "  Turns   : " << node->scr.trns << '\n';
+    cout << setw(15) << " " << "  HiCombo : " << node->scr.cmbHi << "\n\n";
+    inOrder(node->right, rank);
+}
+
+// Public find delegates to the recursive helper starting at root.
+ScoreNode *ScoreBST::find(const string &name)
+{
+    return find(root, name);
+}
+
+// Recursive walk; name is not the ordering key so both subtrees may match.
+ScoreNode *ScoreBST::find(ScoreNode *node, const string &name)
+{
+    //Base Condition: an empty subtree contains no match
+    if (node == nullptr)
+    {
+        return nullptr;
+    }
+    if (node->name == name)
+    {
+        return node;
+    }
+    //Recursion: check left subtree, then right subtree
+    ScoreNode *hit = find(node->left, name);
+    if (hit != nullptr)
+    {
+        return hit;
+    }
+    return find(node->right, name);
+}
+
+int ScoreBST::height() const
+{
+    return height(root);
+}
+
+// Height of a subtree; leaf height is 1, null is 0.
+int ScoreBST::height(ScoreNode *node) const
+{
+    //Base Condition: a null subtree has zero height
+    if (node == nullptr)
+    {
+        return 0;
+    }
+    //Recursion: this node contributes one, plus the taller child
+    int hl = height(node->left);
+    int hr = height(node->right);
+    return 1 + (hl > hr ? hl : hr);
+}
+
+int ScoreBST::count() const
+{
+    return count(root);
+}
+
+// Count of nodes in a subtree, including the root.
+int ScoreBST::count(ScoreNode *node) const
+{
+    //Base Condition: a null subtree owns zero nodes
+    if (node == nullptr)
+    {
+        return 0;
+    }
+    //Recursion: this node counts as one, plus both children
+    return 1 + count(node->left) + count(node->right);
+}

--- a/phase_6_CIS-17C_project2/ScoreBST.h
+++ b/phase_6_CIS-17C_project2/ScoreBST.h
@@ -1,0 +1,42 @@
+#ifndef SCOREBST_H
+#define SCOREBST_H
+#include <string>
+#include "Scores.h"
+using namespace std;
+
+// One leaderboard entry in the tree. Left/right are owned and freed by the
+// containing ScoreBST destructor through a post-order walk.
+struct ScoreNode
+{
+    string name;
+    Scores scr;
+    ScoreNode *left;
+    ScoreNode *right;
+};
+
+// Binary search tree of leaderboard entries, ordered by trns ascending with
+// cmbHi descending as the tiebreak. The tree is rebuilt from scores.dat on
+// every leaderboard view, so the file stays authoritative and the tree never
+// outlives a single render pass.
+class ScoreBST
+{
+public:
+    ScoreBST();
+    ~ScoreBST();
+    void insert(const string &name, const Scores &scr);
+    void inOrder() const;
+    ScoreNode *find(const string &name);
+    int height() const;
+    int count() const;
+
+private:
+    ScoreNode *root;
+    void insert(ScoreNode *&node, const string &name, const Scores &scr);
+    void destroy(ScoreNode *node);
+    void inOrder(ScoreNode *node, int &rank) const;
+    ScoreNode *find(ScoreNode *node, const string &name);
+    int height(ScoreNode *node) const;
+    int count(ScoreNode *node) const;
+};
+
+#endif

--- a/phase_6_CIS-17C_project2/unoV6.0.cpp
+++ b/phase_6_CIS-17C_project2/unoV6.0.cpp
@@ -26,6 +26,7 @@ Purpose: UNO! Game Version 6.0
 #include "Card.h"
 #include "Scores.h"
 #include "HashTable.h"
+#include "ScoreBST.h"
 
 using namespace std;
 
@@ -61,8 +62,6 @@ unordered_set<Card> legalPlays(const list<Card> &, const Card &);               
 void mrgSort(vector<Card> &, int beg, int end);                                                        // Recursive merge sort over the hand vector; mirrors the lab Data* shape
 void merge(vector<Card> &, int beg, int nlow, int nhigh);                                              // Merge step for mrgSort; allocates one span-sized local working buffer
 void showSrt(Player &, const unordered_set<Card> &);                                                   // Display the hand sorted via mrgSort with playable markers
-void qkSort(vector<pair<string, Scores>> &, int lo, int hi);                                           // Recursive quick sort over the leaderboard vector; sorts by trns ascending
-int partition(vector<pair<string, Scores>> &, int lo, int hi);                                         // Hoare partition keyed on Scores.trns; returns the partition index
 void calcScrs(Player &, Player &npc);
 void readScrs();
 void updtScr(const string &, const Scores &);
@@ -490,45 +489,6 @@ void showSrt(Player &p1, const unordered_set<Card> &legal)
         cout << endl;
     }
     cout << "--------------------------------------------------------" << endl;
-}
-
-// Recursive quick sort, vector<pair<string,Scores>> overload keyed on trns ascending.
-void qkSort(vector<pair<string, Scores>> &a, int lo, int hi)
-{
-    //Base Condition: lo >= hi means the range has one or zero elements
-    if (lo < hi)
-    {
-        int p = partition(a, lo, hi);
-        //Recursion
-        qkSort(a, lo, p);
-        qkSort(a, p + 1, hi);
-    }
-}
-
-// Hoare partition over the leaderboard vector. Pivot is the middle entry's trns.
-int partition(vector<pair<string, Scores>> &a, int lo, int hi)
-{
-    int pivot = a[(lo + hi) / 2].second.trns;
-    int i = lo - 1;
-    int j = hi + 1;
-    while (true)
-    {
-        do
-        {
-            i++;
-        } while (a[i].second.trns < pivot);
-        do
-        {
-            j--;
-        } while (a[j].second.trns > pivot);
-        if (i >= j)
-        {
-            return j;
-        }
-        pair<string, Scores> t = a[i];
-        a[i] = a[j];
-        a[j] = t;
-    }
 }
 
 // Build the playable-cards cache for one player turn.
@@ -1028,31 +988,17 @@ void readScrs()
         return;
     }
 
-    // Dump the hash table into a vector and sort by trns ascending. Manual loop
-    // because HashTable::iterator does not expose iterator_traits typedefs.
-    vector<pair<string, Scores>> board;
-    for (HashTable<Scores>::iterator it = scores.begin(); it != scores.end(); ++it)
-    {
-        board.push_back(*it);
-    }
-    if (!board.empty())
-    {
-        qkSort(board, 0, (int)board.size() - 1);
-    }
-
-    cout << "\n"
-         << setw(10) << " " << "=== LEADERBOARD (quickSort, turns asc) ===\n";
-
-    // for_each over the sorted vector keeps the Phase 5 rubric line in place.
-    int count = 1;
-    for_each(board.begin(), board.end(),
-             [&count](const pair<string, Scores> &rec)
+    // for_each over the hash table feeds each record into a fresh ScoreBST.
+    // The tree orders by trns ascending with cmbHi descending tiebreak, so the
+    // in-order walk below prints rank order. The tree is freed at scope exit.
+    ScoreBST tree;
+    for_each(scores.begin(), scores.end(),
+             [&tree](const pair<string, Scores> &rec)
              {
-                 cout << setw(15) << " " << "Rank " << count++ << ":\n";
-                 cout << setw(15) << " " << "  Player  : " << rec.first << '\n';
-                 cout << setw(15) << " " << "  Turns   : " << rec.second.trns << '\n';
-                 cout << setw(15) << " " << "  HiCombo : " << rec.second.cmbHi << "\n\n";
+                 tree.insert(rec.first, rec.second);
              });
+
+    tree.inOrder();
 }
 
 void updtScr(const string &player, const Scores &newScr)


### PR DESCRIPTION
## Summary

Phase 6 sub-version v6.2 (recursive-tree cluster). Two steps land:

- **Step 08** (`bst_class`): new `ScoreBST.h` / `ScoreBST.cpp`. Name-keyed `ScoreNode` with `Scores` value; BST ordering on `(trns ascending, cmbHi descending tiebreak)`; recursive insert / destroy / in-order / find / height / count with Lehr-style `//Base Condition` + `//Recursion` markers on every recursive body. Insert uses `ScoreNode *&` so recursion writes the new leaf into the parent's child slot; destroy is post-order; in-order is classic LNR with a pass-by-reference rank counter; find walks both subtrees because name is not the ordering key. Producer-only commit; `unoV6.0.cpp` untouched.
- **Step 09** (`bst_view`): `readScrs` rewired in `unoV6.0.cpp` to walk the `HashTable<Scores>` through `for_each` and feed each record into a fresh `ScoreBST`, then call `tree.inOrder()` to print the rank-ordered leaderboard; tree freed at scope exit. Pair-vector `qkSort` / `partition` overloads from Step 07 retire (prototypes + 38 lines of definitions removed); their only caller was `readScrs`, and the BST replaces both. The Phase 6 recursive quick-sort rubric line stays carried by the `int*` overload through `sorting_study.cpp`.

The Phase 5 STL non-mutating algorithm rubric line (`for_each`) moves with the wire-in rather than retiring: in v6.1 it walked the sorted vector to print rows; in v6.2 it walks the hash table to feed the tree. Both the Phase 5 algorithm rubric line and the Phase 6 recursive tree walk rubric line execute on the same data each leaderboard read.

Single-pass commit convention: the two atomic working commits (`2876de5` + `5b4ed1d`) folded into one `cb634cb Phase 6 v6.2`. Backup tag `v6.2-backup-pre-rewrite` preserves the prior shape.

## Test plan

- [x] `g++ -std=c++17 -Wall unoV6.0.cpp NPCPlayer.cpp HumanPlayer.cpp ScoreBST.cpp -o uno` builds clean (zero warnings).
- [x] `g++ -std=c++17 -Wall -fsyntax-only ScoreBST.cpp` clean.
- [x] Focused verification driver `/tmp/bst_check` seeds six records in non-rank insertion order (Charlie 42, Alice 18, Bob 27, Diana 9, Eve 35, Frank 27 at cmbHi 8). In-order walk prints Diana 9 / Alice 18 / Frank 27 (cmbHi 8) / Bob 27 (cmbHi 5) / Eve 35 / Charlie 42, confirming `trns` ascending with `cmbHi` descending tiebreak landing the right way at `trns = 27`.
- [x] Driver reports `height = 4`, `count = 6` (balanced shape under this insertion order); `find("Bob")` returns the live node, `find("Zelda")` returns `nullptr`, confirming the recursive helper hits its base case on a no-match walk.