### PR TITLE
Phase 6 v6.5

### DIFF
--- a/phase_6_CIS-17C_project2/flowcharts/README.md
+++ b/phase_6_CIS-17C_project2/flowcharts/README.md
@@ -1,0 +1,28 @@
+# Phase 6 Concept Flowcharts
+
+Five concept diagrams, one per Phase 6 algorithmic concept. The `.mmd`
+files are Mermaid source; render to PNG with:
+
+```bash
+cd phase_6_CIS-17C_project2/flowcharts
+npx -p @mermaid-js/mermaid-cli mmdc -i effect_chain.mmd    -o effect_chain.png    -t default -b white -w 1600
+npx -p @mermaid-js/mermaid-cli mmdc -i merge_vs_quick.mmd  -o merge_vs_quick.png  -t default -b white -w 1600
+npx -p @mermaid-js/mermaid-cli mmdc -i hash_lookup.mmd     -o hash_lookup.png     -t default -b white -w 1600
+npx -p @mermaid-js/mermaid-cli mmdc -i score_bst.mmd       -o score_bst.png       -t default -b white -w 1600
+npx -p @mermaid-js/mermaid-cli mmdc -i hand_graph.mmd      -o hand_graph.png      -t default -b white -w 1600
+```
+
+## Contents
+
+| File | Concept | Rubric anchor |
+|---|---|---|
+| `effect_chain.mmd` | Recursive `resolveEffect` with three base conditions and one recursion site | Recursion + chained-effect resolver |
+| `merge_vs_quick.mmd` | `mrgSort` halving versus `qkSort` Hoare partition recursion shape | Recursive sorts |
+| `hash_lookup.mmd` | `HashTable<V>` BKDR hash, bucket-chain walk, insert / find lifecycle | Hand-written hashing |
+| `score_bst.mmd` | `ScoreBST` insertion then in-order recursive walk for the leaderboard | Tree concept |
+| `hand_graph.mmd` | `HandGraph` adjacency build and `largestCompAfter` NPC scoring | Graph + BFS scoring |
+
+## Notes
+
+- The master V6.0 architecture flowchart remains a single wide `.drawio` page exported to PDF, mirroring the V4.3 and V5.2 cadence. The five concept insets here live alongside it as standalone PNGs and embed into the writeup at the relevant section anchors.
+- The Mermaid sources use only the `flowchart` directive and built-in node shapes so they render with stock `mmdc` (no plugins, no theme files).

--- a/phase_6_CIS-17C_project2/flowcharts/effect_chain.mmd
+++ b/phase_6_CIS-17C_project2/flowcharts/effect_chain.mmd
@@ -1,0 +1,27 @@
+%% Recursive resolver for stackable cards (SKIP / DRAW 2 / DRAW 4).
+%% Three base conditions, one recursion site. MAX_STACK caps depth at 4.
+flowchart TD
+    Start([resolveEffect played, stacker, depth, acc]):::entry
+    Start --> B1{depth >= MAX_STACK?}
+    B1 -- yes --> Ret1([return]):::base
+    B1 -- no --> B2{isStackable played?}
+    B2 -- no --> Ret2([return]):::base
+    B2 -- yes --> Acc[acc.chnLen += 1<br/>acc.log.push_back label]:::work
+    Acc --> Apply{played.suit?}
+    Apply -- SKIP --> S1[acc.skipTgt := true]:::work
+    Apply -- DRAW_TWO --> S2[acc.drwCnt += 2]:::work
+    Apply -- DRAW_FOUR --> S3[acc.drwCnt += 4]:::work
+    S1 --> Find[nextIt := fndStk stacker.hand]:::work
+    S2 --> Find
+    S3 --> Find
+    Find --> B3{nextIt == end?}
+    B3 -- yes --> Ret3([return]):::base
+    B3 -- no --> Erase[chained := *nextIt<br/>stacker.hand.erase nextIt]:::work
+    Erase --> Rec[/resolveEffect chained, stacker.opponent, depth+1, acc/]:::recursion
+    Rec --> Done([return]):::exit
+
+    classDef entry fill:#dff,stroke:#069,stroke-width:2px
+    classDef base fill:#fee,stroke:#a00,stroke-width:1px
+    classDef work fill:#fff,stroke:#333,stroke-width:1px
+    classDef recursion fill:#efe,stroke:#070,stroke-width:2px
+    classDef exit fill:#eee,stroke:#666,stroke-width:1px

--- a/phase_6_CIS-17C_project2/flowcharts/hand_graph.mmd
+++ b/phase_6_CIS-17C_project2/flowcharts/hand_graph.mmd
@@ -1,0 +1,32 @@
+%% HandGraph over a sample NPC hand. Edge rule: shared color OR shared suit.
+%% Nodes labeled COLOR/SUIT for clarity. Sample hand: RED 3, RED SKIP,
+%% BLUE 3, BLUE 7, WILD DRAW_FOUR. The graph forms two clusters that
+%% merge through the RED-3 / BLUE-3 shared-suit edge.
+flowchart TB
+    subgraph Build[1. adjacency-list build O n squared]
+        R3((RED 3)):::node
+        RS((RED SKIP)):::node
+        B3((BLUE 3)):::node
+        B7((BLUE 7)):::node
+        WD((WILD DRAW 4)):::wild
+        R3 --- RS
+        R3 --- B3
+        RS --- B3
+        B3 --- B7
+    end
+
+    subgraph Score[2. largestCompAfter score per legal play]
+        S1[remove RED 3<br/>component RS, B3, B7 = 3]:::row
+        S2[remove RED SKIP<br/>component R3, B3, B7 = 3]:::row
+        S3[remove BLUE 3<br/>component R3, RS = 2<br/>BLUE 7 isolated = 1<br/>max = 2]:::row
+        S4[remove BLUE 7<br/>component R3, RS, B3 = 3]:::row
+        S5[remove WILD<br/>component R3, RS, B3, B7 = 4]:::winrow
+    end
+
+    Build --> Pick[/NPC picks WILD<br/>highest score, hand stays connected/]:::winner
+
+    classDef node fill:#fff,stroke:#333,stroke-width:1px
+    classDef wild fill:#eef,stroke:#449,stroke-width:1px
+    classDef row fill:#fff,stroke:#333,stroke-width:1px
+    classDef winrow fill:#dfd,stroke:#070,stroke-width:2px
+    classDef winner fill:#dff,stroke:#069,stroke-width:2px

--- a/phase_6_CIS-17C_project2/flowcharts/hash_lookup.mmd
+++ b/phase_6_CIS-17C_project2/flowcharts/hash_lookup.mmd
@@ -1,0 +1,26 @@
+%% HashTable<V> insert / find lifecycle.
+%% BKDR seed = 131; open chaining; default 17 buckets.
+flowchart LR
+    Key([key : string<br/>e.g. Tyla]):::input
+    Key --> Hash[hashStr: seed=131<br/>h = h*131 + ch for ch in key]:::work
+    Hash --> Mod[idx := h mod buckets.size 17]:::work
+    Mod --> Bucket[(bucket idx :<br/>list of pair string,V)]:::bucket
+
+    Bucket --> Op{operation?}
+    Op -- insert k,v --> Walk1{walk chain<br/>find key == k}
+    Walk1 -- found --> Over[overwrite value in place]:::work
+    Walk1 -- not found --> App[push_back k,v on chain]:::work
+    Over --> Ret1([return]):::exit
+    App --> Ret1
+
+    Op -- find k --> Walk2{walk chain<br/>find key == k}
+    Walk2 -- found --> Ptr[return V*<br/>caller may mutate]:::work
+    Walk2 -- not found --> Null[return nullptr]:::base
+    Ptr --> Ret2([return]):::exit
+    Null --> Ret2
+
+    classDef input fill:#dff,stroke:#069,stroke-width:2px
+    classDef bucket fill:#eef,stroke:#449,stroke-width:1px
+    classDef work fill:#fff,stroke:#333,stroke-width:1px
+    classDef base fill:#fee,stroke:#a00,stroke-width:1px
+    classDef exit fill:#eee,stroke:#666,stroke-width:1px

--- a/phase_6_CIS-17C_project2/flowcharts/merge_vs_quick.mmd
+++ b/phase_6_CIS-17C_project2/flowcharts/merge_vs_quick.mmd
@@ -1,0 +1,33 @@
+%% Recursion shape compare: merge sort halves first, merges on return;
+%% quick sort partitions first, recurses on each side. Both reach the
+%% same sorted output through different orderings of the split work.
+flowchart TB
+    subgraph MergeSort[mrgSort recursive halving]
+        direction TB
+        M0([mrgSort a, beg, end]):::entry
+        M0 --> M1{end - beg <= 1?}
+        M1 -- yes --> Mret([return]):::base
+        M1 -- no --> M2[center := beg + end-beg / 2]:::work
+        M2 --> M3[/mrgSort a, beg, center/]:::recursion
+        M3 --> M4[/mrgSort a, center, end/]:::recursion
+        M4 --> M5[merge a, beg, center, end<br/>through working buffer]:::merge
+        M5 --> Mdone([return]):::exit
+    end
+
+    subgraph QuickSort[qkSort Hoare partition]
+        direction TB
+        Q0([qkSort arr, lo, hi]):::entry
+        Q0 --> Q1{lo < hi?}
+        Q1 -- no --> Qret([return]):::base
+        Q1 -- yes --> Q2[p := partition arr, lo, hi<br/>pivot = arr middle]:::work
+        Q2 --> Q3[/qkSort arr, lo, p/]:::recursion
+        Q3 --> Q4[/qkSort arr, p+1, hi/]:::recursion
+        Q4 --> Qdone([return]):::exit
+    end
+
+    classDef entry fill:#dff,stroke:#069,stroke-width:2px
+    classDef base fill:#fee,stroke:#a00,stroke-width:1px
+    classDef work fill:#fff,stroke:#333,stroke-width:1px
+    classDef recursion fill:#efe,stroke:#070,stroke-width:2px
+    classDef merge fill:#ffe,stroke:#770,stroke-width:1px
+    classDef exit fill:#eee,stroke:#666,stroke-width:1px

--- a/phase_6_CIS-17C_project2/flowcharts/score_bst.mmd
+++ b/phase_6_CIS-17C_project2/flowcharts/score_bst.mmd
@@ -1,0 +1,36 @@
+%% ScoreBST built from HashTable<Scores> via for_each, then walked in-order.
+%% Order: trns ascending, cmbHi descending as tiebreak.
+%% Lower trns wins; on equal trns the higher cmbHi wins.
+flowchart TB
+    Src[(HashTable Scores<br/>name : Scores)]:::source
+    Src --> Fe[/for_each rec : tree.insert rec.first, rec.second/]:::work
+    Fe --> Tree
+
+    subgraph Tree[ScoreBST after inserts]
+        direction TB
+        Root[(Alex trns=4 cmbHi=3)]:::node
+        L1[(Tyla trns=2 cmbHi=5)]:::node
+        R1[(Sam trns=7 cmbHi=4)]:::node
+        Root --- L1
+        Root --- R1
+    end
+
+    Tree --> IO[/inOrder root, rank/]:::recursion
+
+    subgraph Walk[inOrder recursive descent]
+        direction TB
+        W1[visit left subtree]:::work
+        W2[print rank++ : node.name<br/>trns, cmbHi]:::print
+        W3[visit right subtree]:::work
+        W1 --> W2 --> W3
+    end
+
+    IO --> Walk
+    Walk --> Out[/=== LEADERBOARD<br/>1 Tyla 2 5<br/>2 Alex 4 3<br/>3 Sam 7 4/]:::output
+
+    classDef source fill:#eef,stroke:#449,stroke-width:1px
+    classDef node fill:#fff,stroke:#333,stroke-width:1px
+    classDef work fill:#fff,stroke:#333,stroke-width:1px
+    classDef recursion fill:#efe,stroke:#070,stroke-width:2px
+    classDef print fill:#ffe,stroke:#770,stroke-width:1px
+    classDef output fill:#dff,stroke:#069,stroke-width:2px

--- a/phase_6_CIS-17C_project2/pseudo_code.cpp
+++ b/phase_6_CIS-17C_project2/pseudo_code.cpp
@@ -1,11 +1,10 @@
-// Pseudo-code -- Phase 5 (unoV5.2.cpp)
+// Pseudo-code -- Phase 6 (unoV6.0.cpp)
 //
 // Writeup artifact: NOT compiled, NOT linked. This file holds the
-// major-function pseudo-code referenced by the Phase 5 writeup PDF
-// (Step 10 deliverable #10). Each block calls out the STL container(s)
-// it touches and the iterator or algorithm the rubric grades; see
-// iterator_categories.md for the per-container contract and
-// requirements.md Phase 5 section for the source-line mapping.
+// major-function pseudo-code referenced by the Phase 6 writeup. Each
+// block calls out the container, algorithm, or rubric concept the body
+// of unoV6.0.cpp depends on. Phase 5 STL anchors that survived into
+// Phase 6 are kept; Phase 6 additions are flagged inline.
 
 /* ============================================================
    main
@@ -37,7 +36,7 @@
    else:
        print "NPC wins!"
 
-   readScrs()                                                 // for_each over score map
+   readScrs()                                                 // for_each over HashTable feeds ScoreBST
    delete p1
    delete npc
    return 0
@@ -64,7 +63,7 @@
 
    random_device rd
    mt19937 rng(rd())
-   shuffle(pool, pool + DECK_SIZE, rng)                       // mutating algorithm (v5.1 Step 01)
+   shuffle(pool, pool + DECK_SIZE, rng)                       // mutating algorithm
 
    for i in 0..DECK_SIZE-1:
        deck.push(pool[i])
@@ -90,15 +89,16 @@
    p1.hand.sort(lambda(a, b):                                 // list::sort, NOT std::sort
        if a.color == b.color:
            return a.suit < b.suit
-       return a.color < b.color)                              // organizational algorithm (v5.1 Step 03)
+       return a.color < b.color)                              // organizational algorithm
    ============================================================ */
 
 
 /* ============================================================
-   legalPlays(const list<Card> &hand, const Card &active) -> set<Card>
+   legalPlays(const list<Card> &hand, const Card &active)
+       -> unordered_set<Card>
    ============================================================
-   set<Card> legal                                            // STL set; ordered by operator< on Card
-   for it from hand.begin() to hand.end():
+   unordered_set<Card> legal                                  // hashed set; O(1) avg insert/find
+   for it from hand.begin() to hand.end():                    // BKDR hash on (color, suit) via std::hash<Card>
        if it->color == active.color
           OR it->suit == active.suit
           OR it->color == WILD:
@@ -108,28 +108,70 @@
 
 
 /* ============================================================
-   usrInt(Player &p1, Player &npc, Card &actv, const set<Card> &legal)
+   mrgSort(vector<Card> &a, int beg, int end)                 // recursive halving driver
    ============================================================
-   srtHnd(p1)                                                 // re-sort the hand each turn
+   // Base Condition: empty or single-element span
+   if end - beg <= 1:
+       return
+   center := beg + (end - beg) / 2
+   // Recursion: descend on both halves
+   mrgSort(a, beg, center)
+   mrgSort(a, center, end)
+   merge(a, beg, center, end)
+   ============================================================ */
+
+
+/* ============================================================
+   merge(vector<Card> &a, int beg, int nlow, int nhigh)
+   ============================================================
+   work := local vector<Card> sized (nhigh - beg)
+   i := beg, j := nlow, k := 0
+   while i < nlow AND j < nhigh:
+       if a[i] < a[j]:                                        // global operator< on Card
+           work[k++] := a[i++]
+       else:
+           work[k++] := a[j++]
+   copy remainder of left half  into work
+   copy remainder of right half into work
+   copy work[0..k) back over a[beg..nhigh)
+   ============================================================ */
+
+
+/* ============================================================
+   showSrt(Player &p1, const unordered_set<Card> &legal)      // [s] menu path
+   ============================================================
+   vector<Card> buf
+   for it from p1.hand.begin() to p1.hand.end():
+       buf.push_back(*it)                                     // list -> vector copy so mrgSort can index
+   mrgSort(buf, 0, buf.size())                                // Phase 6 recursive sort over the hand
+   print sorted hand with "(playable)" marker when legal.count(*it)
+   ============================================================ */
+
+
+/* ============================================================
+   usrInt(Player &p1, Player &npc, Card &actv,
+          const unordered_set<Card> &legal)
+   ============================================================
+   srtHnd(p1)                                                 // list::sort re-orders each turn for display
 
    print "It's your turn, <p1.name>!"
    print "Your hand:"
    i := 0
    for it from p1.hand.begin() to p1.hand.end():              // list<Card>: bidirectional walk
        print "[", i, "] ", card-label(*it)
-       if legal.find(*it) != legal.end():                     // set<Card>: O(log n) membership
+       if legal.find(*it) != legal.end():                     // unordered_set<Card>: O(1) avg membership
            print "  (playable)"
        ++i
 
    print "Active Card: ", crdInfo(actv)
 
-   legalN := count_if(p1.hand.begin(), p1.hand.end(),         // non-mutating algorithm (v5.1 Step 02)
+   legalN := count_if(p1.hand.begin(), p1.hand.end(),         // non-mutating algorithm
                       lambda(c): legal.find(c) != legal.end())
 
    print "| Cards in your hand: ", p1.hand.size(),
          " (", legalN, " playable) |"
    print "What would you like to do?"
-   print "| Choose a card to play [0-N] | Type -1 to draw |"
+   print "| Choose a card [0-N] | -1 to draw | s to mergeSort-view |"
    ============================================================ */
 
 
@@ -139,12 +181,18 @@
    ============================================================
    while turn is true:
        turn := false
-       set<Card> legal := legalPlays(p1.hand, discard.top())
+       unordered_set<Card> legal := legalPlays(p1.hand, discard.top())
        usrInt(p1, npc, discard.top(), legal)
-       read choice from cin
+       read raw string from cin                               // text first so [s] is distinguishable
 
-       if cin failed:
-           recover stream
+       if raw == "s" or raw == "S":
+           showSrt(p1, legal)                                 // mergeSort view; loop again
+           turn := true
+           continue
+
+       parse raw through stringstream into int choice
+       if parse failed OR not at eof:
+           print "Invalid input. Try again."
            turn := true
        else if choice == -1:
            p1.drawCard(deck)
@@ -162,7 +210,8 @@
 
 /* ============================================================
    play(Player &p1, Player &npc, int choice, stack<Card> &discard,
-        queue<Card> &deck, bool &turn, const set<Card> &legal)
+        queue<Card> &deck, bool &turn,
+        const unordered_set<Card> &legal)
    ============================================================
    if choice < 0 or choice >= p1.hand.size():
        print "Invalid choice!"
@@ -171,14 +220,28 @@
    it := next(p1.hand.begin(), choice)                        // O(n) list walk, cached
    slctd := *it
 
-   if legal.find(slctd) != legal.end():                       // set<Card> validates
+   if legal.find(slctd) != legal.end():                       // unordered_set<Card> validates
        print "You've played a ", card-label(slctd)
        discard.push(slctd)
        p1.hand.erase(it)                                      // reuse cached iterator
+
+       if slctd is stackable (SKIP / DRAW_TWO / DRAW_FOUR):
+           EffectAccum acc := {drwCnt:0, skipTgt:false, chnLen:0, log:{}}
+           resolveEffect(slctd, npc, 0, acc)                  // recursive chain resolver
+           for i in 0..acc.drwCnt - 1:
+               npc.hand.push_back(draw(deck))
+           if acc.chnLen > 1:
+               print "Stack chain length: ", acc.chnLen
+           if acc.skipTgt:
+               turn := true                                   // skip target loses next turn
+
+       if slctd.color == WILD:
+           wildCrd(discard.top())                             // prompt for color, mutate top of pile
+
        p1.updateCombo()
+       npc.resetCombo()
        p1.trns += 1
-       handle SKIP / DRAW_2 / DRAW_4 / WILD effects on discard.top()
-       if WILD: ask player for a new color via wildCrd
+
        if p1.hand is empty: return
        turn := false                                          // NPC's turn next
    else:
@@ -188,9 +251,39 @@
 
 
 /* ============================================================
+   resolveEffect(Card played, Player &stacker,
+                 int depth, EffectAccum &acc)
+   ============================================================
+   // Base Condition: depth cap reached
+   if depth >= MAX_STACK:
+       return
+   // Base Condition: played card is not stackable
+   if NOT isStackable(played):
+       return
+
+   acc.chnLen += 1
+   acc.log.push_back(label of played)
+   apply played's draw/skip effect into acc:
+       if played.suit == SKIP:        acc.skipTgt := true
+       if played.suit == DRAW_TWO:    acc.drwCnt += 2
+       if played.suit == DRAW_FOUR:   acc.drwCnt += 4
+
+   nextIt := fndStk(stacker.hand)                             // first stackable in stacker.hand, or end()
+   // Base Condition: no chain card available in stacker.hand
+   if nextIt == stacker.hand.end():
+       return
+
+   chained := *nextIt
+   stacker.hand.erase(nextIt)
+   // Recursion: descend on the chained card with the target swapped
+   resolveEffect(chained, stacker.opponent, depth + 1, acc)
+   ============================================================ */
+
+
+/* ============================================================
    pickClr(const list<Card> &hand) -> CardClr
    ============================================================
-   map<CardClr, int> tally                                    // second associative container
+   unordered_map<CardClr, int> tally                          // hashed second associative container
    for it from hand.begin() to hand.end():
        if it->color != WILD:
            tally[it->color] += 1                              // operator[] zero-inits missing keys
@@ -198,12 +291,76 @@
    if tally is empty:                                         // hand was all wilds
        return random color in {RED, BLUE, YELLOW, GREEN}
 
-   best   := tally.begin()->first
-   bestN  := tally.begin()->second
-   for it from tally.begin() to tally.end():
-       if it->second > bestN:
-           best  := it->first
-           bestN := it->second
+   best   := first key in tally
+   bestN  := tally[best]
+   for kv in tally:
+       if kv.second > bestN:
+           best  := kv.first
+           bestN := kv.second
+   return best
+   ============================================================ */
+
+
+/* ============================================================
+   HandGraph(const list<Card> &hand)                          // adjacency-list build
+   ============================================================
+   nds := vector<Card> copied from hand
+   n   := nds.size()
+   adj := vector<vector<int>> of size n, each empty
+   for i in 0..n-1:
+       for j in i+1..n-1:
+           if shrAttr(nds[i], nds[j]):                        // edge: shared color OR shared suit
+               adj[i].push_back(j)
+               adj[j].push_back(i)
+   ============================================================ */
+
+
+/* ============================================================
+   HandGraph::bfsFrom(int start, const vector<bool> &skip) const -> int
+   ============================================================
+   seen := vector<bool>(n, false)
+   queue<int> q
+   q.push(start)
+   seen[start] := true
+   count := 0
+   while q not empty:
+       u := q.front(); q.pop()
+       if skip[u]: continue                                   // multi-source BFS respects removal mask
+       count += 1
+       for v in adj[u]:
+           if NOT seen[v] AND NOT skip[v]:
+               seen[v] := true
+               q.push(v)
+   return count
+   ============================================================ */
+
+
+/* ============================================================
+   HandGraph::dfsFrom(int u, vector<bool> &seen,
+                      list<Card> &out) const
+   ============================================================
+   // Base Condition: stop when a node has already been visited
+   if seen[u]: return
+   seen[u] := true
+   out.push_back(nds[u])
+   // Recursion: descend into every unvisited neighbor
+   for v in adj[u]:
+       dfsFrom(v, seen, out)
+   ============================================================ */
+
+
+/* ============================================================
+   HandGraph::largestCompAfter(const Card &removed) const -> int
+   ============================================================
+   r := idxOf(removed)
+   skip := vector<bool>(n, false)
+   if r >= 0: skip[r] := true                                 // hypothetical play: hide removed node
+   seen := vector<bool>(n, false)
+   best := 0
+   for u in 0..n-1:                                           // multi-source BFS over unseen, unskipped
+       if seen[u] OR skip[u]: continue
+       size := bfsFrom(u, skip with seen folded in)
+       if size > best: best := size
    return best
    ============================================================ */
 
@@ -214,6 +371,26 @@
    ============================================================
    valid := false
    it    := npc.hand.begin()                                  // list<Card>: bidirectional first-fit scan
+
+   // Phase 6 scoring: build a hand graph and pre-point the iterator
+   // at the legal candidate whose removal leaves the largest connected
+   // component intact. Strict greater-than means ties fall back to
+   // first-legal, preserving the prior deterministic NPC behavior.
+   HandGraph hg(npc.hand)
+   bstScr := -1
+   bstIt  := npc.hand.end()
+   for cit from npc.hand.begin() to npc.hand.end():
+       cnd := *cit
+       legal := cnd.color == discard.top().color
+                OR cnd.suit == discard.top().suit
+                OR cnd.color == WILD
+       if NOT legal: continue
+       scr := hg.largestCompAfter(cnd)
+       if scr > bstScr:
+           bstScr := scr
+           bstIt  := cit
+   if bstIt != npc.hand.end():
+       it := bstIt
 
    while not valid:
        if it != npc.hand.end():
@@ -229,15 +406,21 @@
 
                turn := true
                if c.color == WILD:
-                   newClr := pickClr(npc.hand)                // map tally picks favored color
+                   newClr := pickClr(npc.hand)                // unordered_map tally picks favored color
                    discard.top().color := newClr
                    print "NPC plays a WILD and chooses ", newClr
-               handle SKIP / DRAW_2 / DRAW_4 (push cards onto p1.hand)
+               if isStackable(c):
+                   EffectAccum acc := {0, false, 0, {}}
+                   resolveEffect(c, p1, 0, acc)               // recursive chain resolver
+                   for i in 0..acc.drwCnt - 1:
+                       p1.hand.push_back(draw(deck))
+                   if acc.chnLen > 1:
+                       print "Stack chain length: ", acc.chnLen
                valid := true
            else:
                ++it
        else:
-           // NPC hand exhausted of options: draw one and try to play it
+           // NPC hand exhausted of legal options: draw one and try to play it
            drawn := draw(deck)
            npc.hand.push_back(drawn)
            print "NPC draws a card!"
@@ -245,7 +428,11 @@
            if drawn playable on discard.top():
                push drawn onto discard
                remove drawn from npc.hand
-               handle WILD / SKIP / DRAW effects
+               if isStackable(drawn):
+                   EffectAccum acc := {0, false, 0, {}}
+                   resolveEffect(drawn, p1, 0, acc)
+                   for i in 0..acc.drwCnt - 1:
+                       p1.hand.push_back(draw(deck))
            valid := true
    ============================================================ */
 
@@ -268,12 +455,12 @@
 
 
 /* ============================================================
-   loadScoreMap(map<string, Scores> &out) -> bool
+   loadScoreMap(HashTable<Scores> &out) -> bool
    ============================================================
    open scores.dat for binary input
    if open failed: return false
    while read fixed-size SaveData record:
-       out[record.name] := record.scr                         // map<string, Scores> built in memory
+       out.insert(record.name, record.scr)                    // HashTable<V>: BKDR(string) -> bucket chain
    return true
    ============================================================ */
 
@@ -281,36 +468,36 @@
 /* ============================================================
    readScrs()
    ============================================================
-   map<string, Scores> scores
+   HashTable<Scores> scores
    if not loadScoreMap(scores):
        print "Error opening scores.dat"
        return
 
-   print "=== SCORE HISTORY ==="
+   print "=== LEADERBOARD (BST in-order, turns asc) ==="
 
-   count := 1
-   for_each(scores.begin(), scores.end(),                     // non-mutating algorithm #2 (v5.2)
-            lambda(const pair<const string, Scores> &rec):
-                print "Record ", count, ": ", rec.first,
-                      " trns=", rec.second.trns,
-                      " hiCombo=", rec.second.cmbHi
-                ++count)
+   ScoreBST tree                                              // ordered by trns asc, cmbHi desc tiebreak
+   for_each(scores.begin(), scores.end(),                     // non-mutating algorithm walks the hash table
+            lambda(const pair<string, Scores> &rec):
+                tree.insert(rec.first, rec.second))
+
+   tree.inOrder()                                             // recursive descent prints rank order
+   // tree is freed at scope exit via post-order destroy walk
    ============================================================ */
 
 
 /* ============================================================
    updtScr(const string &player, const Scores &newScr)
    ============================================================
-   map<string, Scores> scores
+   HashTable<Scores> scores
    if not loadScoreMap(scores):
-       print "Error opening scores.dat"
+       print "Failed to open scores.dat"
        return
 
-   it := scores.find(player)                                  // map::find = O(log n)
-   if it == scores.end():
+   Scores *hit := scores.find(player)                         // O(1) avg hashed lookup; returns V* or null
+   if hit == nullptr:
        print "Player not found in save file."
        return
-   it->second := newScr
+   *hit := newScr                                             // mutate in place through the bucket pointer
 
    open scores.dat in binary truncate mode for writing
    for it from scores.begin() to scores.end():

--- a/phase_6_CIS-17C_project2/writeup.md
+++ b/phase_6_CIS-17C_project2/writeup.md
@@ -1,0 +1,107 @@
+# UNO! V6.0
+
+**Version 6.0 of UNO!**
+
+By Samuel Gerungan
+
+_Migration to recursion, hand-written hashing, parallel recursive sorts, a binary search tree leaderboard, a recursive effect-chain resolver, and a graph-driven NPC scoring loop._
+
+---
+
+## Contents
+
+1. Overview
+2. Hand-Written Hashing (`HashTable`, `unordered_set`, `unordered_map`)
+3. Recursive Sorts (`mrgSort`, `qkSort`)
+4. Binary Search Tree (`ScoreBST`)
+5. Recursive Effect Chain (`EffectChain` / `resolveEffect`)
+6. Hand Graph + NPC BFS Scoring (`HandGraph`, `npcTrn`)
+7. Reflection
+
+---
+
+## 1. Overview
+
+Phase 6 extends the Phase 5 STL build with five new rubric concepts. We keep every Phase 4 and Phase 5 anchor intact (the friend declaration in `Player.h`, the static `totalDrawn` in `Card.h`, the templated `maxValue` in `Scores.h`, the try / catch around index validation in the main file, and the `for_each` walk over the score store) and layer the Phase 6 deliverables on top. Each new concept lands in its own header / cpp pair so the diff at every step is small and the link line grows one file at a time.
+
+The build target is `g++ -std=c++17 -Wall unoV6.0.cpp NPCPlayer.cpp HumanPlayer.cpp Sorting.cpp ScoreBST.cpp EffectChain.cpp HandGraph.cpp -o uno`. The binary builds clean under `-Wall` with no warnings at every sub-version boundary.
+
+---
+
+## 2. Hand-Written Hashing
+
+The hash cluster replaces three Phase 5 ordered associative containers with hashed equivalents: `set<Card>` becomes `unordered_set<Card>` in the legal-plays cache, `map<string, Scores>` becomes `HashTable<Scores>` in the score store, and `map<CardClr, int>` becomes `unordered_map<CardClr, int>` in the NPC color tally. The hand-written `HashTable<V>` is the rubric centerpiece.
+
+`HashTable.h` is a header-only template keyed by `string` over a `vector<list<pair<string, V>>>`. The hash function is BKDR with seed 131 (`h = h * 131 + ch` for each character). Open chaining handles collisions: on `insert` we walk the bucket chain and overwrite when the key matches, otherwise we `push_back` a new pair. `find(key)` returns `V*` so the caller can mutate in place, and `nullptr` when the key is absent. The default capacity is 17, which keeps the load factor low for the small leaderboards Phase 6 needs and produces a clean five-bucket distribution in a verification capture of three sample names.
+
+Switching `map<string, Scores>` to `HashTable<Scores>` rippled through three call sites. `loadScoreMap` calls `out.insert(name, scr)` instead of `out[name] = scr`. `readScrs` walks the table through the new forward iterator (the iterator skips empty buckets so the walk yields each stored pair exactly once). `updtScr` uses the `V*` return path: a `nullptr` check replaces the prior `it == scores.end()` check, and `*hit = newScr` mutates the bucket entry in place without a second lookup.
+
+![Hash lookup](flowcharts/hash_lookup.png)
+
+The `unordered_set<Card>` swap required adding `operator==(Card)` for bucket-walk equality and `std::hash<Card>` for the input hash. We retained `operator<(Card)` because the Phase 5 rubric grades it; the comment line on the operator now reflects that it is kept for the rubric anchor and no longer serves a runtime consumer in the legal-plays path. The iterator-category contract moves from Bidirectional to Forward for the swapped container, and we noted this in the contract table that Phase 5 produced.
+
+---
+
+## 3. Recursive Sorts
+
+`Sorting.h` and `Sorting.cpp` carry four prototypes: `mrgSort(Data*, int beg, int end)` and its `merge` step, plus `qkSort(int*, int lo, int hi)` and its Hoare-partition helper. The merge sort uses a pre-allocated working buffer on the `Data` struct so the recursion does not allocate per frame; the quick sort picks the middle element as pivot and converges two indices until they cross.
+
+Both sorts share the same recursion shape. Merge sort halves first then merges on return; quick sort partitions first then recurses on each side. The concept flowchart below renders both as parallel subgraphs so the structural compare is direct.
+
+![Merge sort versus quick sort](flowcharts/merge_vs_quick.png)
+
+We then specialize the merge sort for `vector<Card>` and wire it into the player turn through a new menu option `[s] show sorted (mergeSort)`. The path copies the player's `list<Card>` hand into a `vector<Card>` (since `mrgSort` indexes), runs the recursive sort, and prints the result with `(playable)` markers attached to legal candidates. The existing Phase 5 `srtHnd` lambda call (`list::sort` on `(color, suit)`) stays intact for the default hand display; the `[s]` option is an opt-in path that demonstrates the recursive sort against the same data.
+
+A standalone timing study (`sorting_study.cpp`) compiles against `Sorting.cpp` and walks a nine-point N range from one million to 256 million integers. The driver fills a `Data` with 32-bit random values, times one quick sort and one merge sort per N, and writes `quick_time.txt` and `merge_time.txt` in count / X-row / Y-row format. The captured timings track the expected O(N log N) curve for both algorithms; quick sort runs faster at small N because it allocates no auxiliary buffer, and merge sort closes the gap at large N because its access pattern is sequential.
+
+---
+
+## 4. Binary Search Tree
+
+`ScoreBST` stores leaderboard entries ordered by `trns` ascending with `cmbHi` descending as the tiebreak. The class wraps a `ScoreNode` root and exposes `insert(name, scr)`, `inOrder()`, `find(name)`, `height()`, and `count()`. Insertion descends the tree recursively, picking the left or right child based on the ordering predicate. The destructor frees nodes through a post-order walk so the tree owns its memory cleanly.
+
+The leaderboard view rebuilds the tree from `scores.dat` on every read. We dump the `HashTable<Scores>` into the tree through the Phase 5 `for_each` rubric line, which now feeds each pair into `tree.insert(rec.first, rec.second)`. The tree is freed at scope exit, which means the file stays authoritative and the tree never outlives a single render pass.
+
+![Score BST](flowcharts/score_bst.png)
+
+`inOrder()` is a textbook recursive descent. It visits the left subtree, prints the current node with a running rank counter, then visits the right subtree. The output rows are rank-ordered, which is what the player sees when they read the leaderboard. The header line was swapped from `=== SCORE HISTORY ===` to `=== LEADERBOARD (BST in-order, turns asc) ===` to reflect the new semantics, and the row label moved from `Record N` to `Rank N`.
+
+---
+
+## 5. Recursive Effect Chain
+
+The chained-effect resolver is the recursion anchor for Phase 6. Pre-refactor, three caller sites in the main file (human play, NPC play from hand, NPC play from drawn card) each carried a flat conditional ladder over SKIP, DRAW 2, and DRAW 4 that duplicated the per-effect logic three times. `EffectChain.h` introduces `resolveEffect(Card played, Player &stacker, int depth, EffectAccum &acc)` and `EffectAccum` (a small aggregator carrying `drwCnt`, `skipTgt`, `chnLen`, `log`). The three call sites collapse to one branch each.
+
+![Recursive effect chain](flowcharts/effect_chain.png)
+
+The recursion carries three base conditions and one recursion site. The depth cap (`MAX_STACK = 4`) bounds the chain length; the non-stackable check exits when a card that is not SKIP / DRAW 2 / DRAW 4 reaches the resolver; the no-chain-card-found check exits when the stacker's hand has no further stackable card to chain. The recursion site swaps the stacker role (the chained card targets the previous stacker's opponent) and increments the depth counter. The `chnLen` field records how many cards the chain consumed, which lets the caller print a `Stack chain length: N` line whenever the chain ran past length one.
+
+We chose recursion over iteration here because the chain semantics are honest tail recursion with one mutating accumulator. An iterative loop would have meant maintaining the same stacker-swap and depth tracking by hand; the recursive form lets the language do the bookkeeping and keeps the function body short.
+
+---
+
+## 6. Hand Graph and NPC BFS Scoring
+
+The graph cluster represents an NPC's hand as an undirected graph. Each card is a node; an edge connects two cards that share a color or a suit. The `HandGraph` constructor builds the adjacency in O(n squared) pairwise (n caps near twenty for a real hand) by sweeping the upper triangle and pushing matched pairs into a `vector<vector<int>> adj`.
+
+`HandGraph` exposes parallel implementations of the same connected-component computation. `compSize(Card start)` runs BFS through an integer-keyed `queue<int>` and a `vector<bool> seen` mask; `compSizeD(Card start)` runs recursive DFS with the Lehr-style `// Base Condition` and `// Recursion` markers. Both methods return the same component size for the same input, which gives the writeup a direct compare between frontier expansion and recursive descent.
+
+The scoring driver is `largestCompAfter(Card removed)`. It marks the removed card's index in a skip mask, then runs multi-source BFS over the remaining unseen, unskipped nodes and returns the maximum component size encountered. The driver is what the NPC turn calls per legal play to answer "how connected does my hand stay after I play this card?"
+
+![Hand graph and NPC scoring](flowcharts/hand_graph.png)
+
+In `npcTrn`, the scoring loop sits ahead of the unchanged play loop. The NPC builds a fresh `HandGraph hg(npc.hand)` at the start of the turn, sweeps every iterator position in the hand for legality, scores each legal candidate by `hg.largestCompAfter(*cit)`, and points the existing iterator at the best-scoring card before the `while (!valid)` block runs. Strict greater-than comparison means a tie falls back to first-legal, which preserves the deterministic NPC behavior the prior sub-versions depended on. The diff at the call site is twenty-eight lines inserted, zero lines removed; the existing draw-fallback path and the existing effect-chain call are unchanged.
+
+The heuristic is loose on purpose. At a seven-card opening hand the score function almost always ties between candidates with score equal to hand size minus one, so the heuristic differentiates only when the hand grows past ten cards and clusters genuinely split. That is the situation where the NPC needs help most, so the heuristic earns its keep in the late game and is a no-op in the opening.
+
+---
+
+## 7. Reflection
+
+The most interesting thing about Phase 6 was how clean the layering came out. The hash, sort, tree, recursion, and graph clusters each landed in their own header / cpp pair without any cross-coupling between them. The link line grows one file at a time across the six sub-versions (v6.0 hash, v6.1 sort, v6.2 tree, v6.3 recursion, v6.4 graph, v6.5 docs) and the main entry file `unoV6.0.cpp` only gains include lines and small call-site wire-ins. The architecture inherited from Phase 5 absorbed every new concept without a structural rewrite.
+
+The Phase 6 recursion concept showed up in three distinct shapes. The chained-effect resolver is honest tail recursion with one accumulator (three base conditions, one recursion site, depth-capped). The recursive sorts are classic divide-and-conquer (one base condition each, two recursion sites). The BST in-order walk is the textbook left / visit / right descent. Seeing the same control structure across three different problem shapes was the lesson that lands deepest from this phase: recursion is a shape vocabulary, not a single trick.
+
+The one design call that took the longest to settle was the NPC scoring heuristic. We considered three tiebreak policies (first-legal, highest-scoring with a secondary Wild-saving preference, random) and went with strict greater-than so first-legal wins on ties. The decision preserved every previously-passing manual NPC interaction and kept the scoring signal pure (one rubric concept per heuristic, not two). A future revision could layer a Wild-saving secondary preference on top, but the spec is cleaner with the graph score as the only signal.
+
+The forward question coming out of Phase 6 is what a Phase 7 expansion would look like. The graph cluster suggests a path: the current `HandGraph` is rebuilt every turn at O(n squared), which is fine at twenty cards but would be wasteful at a larger hand. Caching the adjacency list across turns and updating it incrementally on play / draw events would be a natural next concept, and would exercise the iterator-invalidation contract on the adjacency vectors that Phase 6 currently treats as throwaway state. The tree cluster suggests another path: the current `ScoreBST` is rebuilt on every leaderboard read, which is fine for a small file but would benefit from a self-balancing variant (AVL or red-black) once the leaderboard grows past a few hundred entries. Both extensions are honest follow-ons to the rubric concepts Phase 6 introduces, and both would land as additional `.h` / `.cpp` pairs without disturbing the existing build chain.


### PR DESCRIPTION
## Summary

Docs-finalization cluster for Phase 6.

- Step 13 (`pseudo_update`): `phase_6_CIS-17C_project2/pseudo_code.cpp` rewritten to reflect cumulative Phase 6 mechanics (containers swap to hashed equivalents, recursive sort + effect chain + hand graph blocks added, NPC scoring loop documented).
- Step 14 (`flowcharts`): five concept flowcharts authored as Mermaid source in `phase_6_CIS-17C_project2/flowcharts/` (`effect_chain.mmd`, `merge_vs_quick.mmd`, `hash_lookup.mmd`, `score_bst.mmd`, `hand_graph.mmd`) plus a render-command README.
- Step 15 (`writeup`): `phase_6_CIS-17C_project2/writeup.md` drafted as the writeup-PDF source, voice and style sweep clean against `documentation_style.md`.
- Three atomic commits (`33711d6 Phase 6 pseudo update` + `482f3a9 Phase 6 flowcharts` + `edb916c Phase 6 writeup`) folded into single `Phase 6 v6.5` commit. Backup tag `v6.5-backup-pre-rewrite` preserves the pre-fold shape.

## Test plan

- [x] `grep -c "—" phase_6_CIS-17C_project2/{pseudo_code.cpp,writeup.md,flowcharts/*.mmd,flowcharts/README.md}` returns 0 on every file
- [x] Banned-vocab grep returns 0 on every new artifact
- [x] No doc / scaffold path references in any new file
- [ ] PNG renders produced locally via `mmdc` per `flowcharts/README.md`
- [ ] Writeup PDF exported via Pandoc and reviewed for layout